### PR TITLE
avoid passing new prop refs each time `teleparent` gets rendered

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,8 @@ const teleparent = Wrapped => class Teleparent extends React.Component {
     super(props)
     this.keys = []
     this.namedKeys = {}
+    this._makeKey = this._makeKey.bind(this);
+    this.getKey = this.getKey.bind(this);
   }
   componentWillUnMount() {
     this.keys.forEach(key => {
@@ -115,8 +117,8 @@ const teleparent = Wrapped => class Teleparent extends React.Component {
   }
   render() {
     return <Wrapped
-      getTelekey={this.getKey.bind(this)}
-      makeTelekey={this._makeKey.bind(this)}
+      getTelekey={this.getKey}
+      makeTelekey={this._makeKey}
       {...this.props}/>
   }
 }


### PR DESCRIPTION
Here is a perf change in these lines :

https://github.com/jaredly/react-teleporter/blob/master/index.js#L118
https://github.com/jaredly/react-teleporter/blob/master/index.js#L119

Knowing that `Function#bind` creates a new function, the `Wrapped` component will therefore receive new references in each render which will make it update (when its parent updates) even if it extends the `PureComponent` class.